### PR TITLE
fix: look for setup attr in the entire sdp

### DIFF
--- a/crates/sdp/src/resolvers.rs
+++ b/crates/sdp/src/resolvers.rs
@@ -4,7 +4,12 @@ use std::net::SocketAddr;
 use rand::{Rng, RngCore, thread_rng};
 use rand::distr::Alphanumeric;
 
-use crate::line_parsers::{Attribute, AudioCodec, Candidate, ConnectionData, Feedback, FeedbackType, Fingerprint, FMTP, ICEOption, ICEOptions, ICEPassword, ICEUsername, MediaCodec, MediaDescription, MediaGroup, MediaID, MediaSSRC, MediaTransportProtocol, MediaType, Originator, RTPMap, SDPLine, SDPParseError, SessionTime, Setup, SourceAttribute, VideoCodec};
+use crate::line_parsers::{
+    Attribute, AudioCodec, Candidate, ConnectionData, Feedback, FeedbackType, Fingerprint,
+    FMTP, ICEOption, ICEOptions, ICEPassword, ICEUsername, MediaCodec, MediaDescription,
+    MediaGroup, MediaID, MediaSSRC, MediaTransportProtocol, MediaType, Originator, RTPMap,
+    SDPLine, SDPParseError, SessionTime, Setup, SourceAttribute, VideoCodec,
+};
 
 #[derive(Debug, Clone)]
 pub struct SDP {
@@ -88,6 +93,7 @@ pub struct AudioSession {
     pub remote_ssrc: Option<u32>,
 }
 
+#[derive(Debug, Clone)]
 pub struct SDPResolver {
     fingerprint: Fingerprint,
     candidate: Candidate,
@@ -165,8 +171,8 @@ impl SDPResolver {
     }
 
     /** Gets ICE credentials from the SDP. Uses session-level credentials if no media-level credentials were provided.
-                                                                                                                                                       If media-level credentials were provided, check if they match across media-streams and if so resolve to ICECredentials.
-     */
+                                                                                                                                                        If media-level credentials were provided, check if they match across media-streams and if so resolve to ICECredentials.
+    */
     fn get_ice_credentials(sdp: &SDP) -> Option<ICECredentials> {
         let get_ice_username = |section: &Vec<SDPLine>| {
             section.iter().find_map(|line| match line {
@@ -380,17 +386,25 @@ impl SDPResolver {
             })
             .ok_or(SDPParseError::MissingVideoCapabilities)?;
 
-        let supports_nack = video_media.iter().find(|&item| item == &SDPLine::Attribute(Attribute::Feedback(Feedback {
-            payload_type: accepted_codec_payload_number,
-            feedback_type: FeedbackType::NACK,
-        }))
-        ).is_some();
+        let supports_nack = video_media
+            .iter()
+            .find(|&item| {
+                item == &SDPLine::Attribute(Attribute::Feedback(Feedback {
+                    payload_type: accepted_codec_payload_number,
+                    feedback_type: FeedbackType::NACK,
+                }))
+            })
+            .is_some();
 
-        let supports_pli = video_media.iter().find(|&item| item == &SDPLine::Attribute(Attribute::Feedback(Feedback {
-            payload_type: accepted_codec_payload_number,
-            feedback_type: FeedbackType::PLI,
-        }))
-        ).is_some();
+        let supports_pli = video_media
+            .iter()
+            .find(|&item| {
+                item == &SDPLine::Attribute(Attribute::Feedback(Feedback {
+                    payload_type: accepted_codec_payload_number,
+                    feedback_type: FeedbackType::PLI,
+                }))
+            })
+            .is_some();
 
         Ok(VideoSession {
             codec: Self::ACCEPTED_VIDEO_CODEC,
@@ -481,22 +495,25 @@ impl SDPResolver {
         let audio_session = Self::get_streamer_audio_session(&sdp_offer.audio_section)?;
         let video_session = Self::get_streamer_video_session(&sdp_offer.video_section)?;
 
-        let is_passive_dtls_role = sdp_offer
+        let is_active_dtls_role = sdp_offer
             .session_section
             .iter()
-            .find_map(|item| match item {
+            .chain(sdp_offer.audio_section.iter())
+            .chain(sdp_offer.video_section.iter())
+            .find(|item| match item {
                 SDPLine::Attribute(attr) => match attr {
                     Attribute::Setup(setup) => match setup {
-                        Setup::Passive => Some(true),
-                        _ => Some(false),
+                        Setup::Passive => true,
+                        Setup::ActivePassive => true,
+                        _ => false,
                     },
-                    _ => None,
+                    _ => false,
                 },
-                _ => None,
+                _ => false,
             })
-            .ok_or(SDPParseError::MalformedSDPLine)?;
+            .is_some();
 
-        if is_passive_dtls_role {
+        if !is_active_dtls_role {
             return Err(SDPParseError::InvalidDTLSRole);
         }
 
@@ -816,18 +833,27 @@ impl SDPResolver {
             _ => None,
         });
 
+        let supports_nack = video_media
+            .iter()
+            .find(|&item| {
+                item == &SDPLine::Attribute(Attribute::Feedback(Feedback {
+                    payload_type: resolved_payload_number,
+                    feedback_type: FeedbackType::NACK,
+                }))
+            })
+            .is_some()
+            && streamer_session.feedback_support.supports_nack;
 
-        let supports_nack = video_media.iter().find(|&item| item == &SDPLine::Attribute(Attribute::Feedback(Feedback {
-            payload_type: resolved_payload_number,
-            feedback_type: FeedbackType::NACK,
-        }))
-        ).is_some() && streamer_session.feedback_support.supports_nack;
-
-        let supports_pli = video_media.iter().find(|&item| item == &SDPLine::Attribute(Attribute::Feedback(Feedback {
-            payload_type: resolved_payload_number,
-            feedback_type: FeedbackType::PLI,
-        }))
-        ).is_some() && streamer_session.feedback_support.supports_pli;
+        let supports_pli = video_media
+            .iter()
+            .find(|&item| {
+                item == &SDPLine::Attribute(Attribute::Feedback(Feedback {
+                    payload_type: resolved_payload_number,
+                    feedback_type: FeedbackType::PLI,
+                }))
+            })
+            .is_some()
+            && streamer_session.feedback_support.supports_pli;
 
         Ok(VideoSession {
             capabilities: legal_video_fmtp.clone(),
@@ -1092,7 +1118,13 @@ mod tests {
             use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
             use std::str::FromStr;
 
-            use crate::line_parsers::{Attribute, AudioCodec, Candidate, ConnectionData, Feedback, FeedbackType, Fingerprint, FMTP, HashFunction, ICEOption, ICEOptions, ICEPassword, ICEUsername, MediaCodec, MediaDescription, MediaGroup, MediaID, MediaSSRC, MediaTransportProtocol, MediaType, Originator, RTPMap, SDPLine, SessionTime, Setup, SourceAttribute, VideoCodec};
+            use crate::line_parsers::{
+                Attribute, AudioCodec, Candidate, ConnectionData, Feedback, FeedbackType,
+                Fingerprint, FMTP, HashFunction, ICEOption, ICEOptions, ICEPassword,
+                ICEUsername, MediaCodec, MediaDescription, MediaGroup, MediaID,
+                MediaSSRC, MediaTransportProtocol, MediaType, Originator, RTPMap, SDPLine, SessionTime,
+                Setup, SourceAttribute, VideoCodec,
+            };
             use crate::resolvers::SDPResolver;
 
             const VALID_SDP: &str = "v=0\r\no=rtc 3767197920 0 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\na=group:BUNDLE 0 1\r\na=group:LS 0 1\r\na=msid-semantic:WMS *\r\na=setup:actpass\r\na=ice-ufrag:E2Fr\r\na=ice-pwd:OpQzg1PAwUdeOB244chlgd\r\na=ice-options:trickle\r\na=fingerprint:sha-256 EF:53:C9:F2:E0:A0:4F:1D:5E:99:4C:20:B8:D7:DE:21:3B:58:15:C4:E5:88:87:46:65:27:F7:3B:C6:DC:EF:3B\r\nm=audio 4557 UDP/TLS/RTP/SAVPF 111\r\nc=IN IP4 192.168.0.198\r\na=mid:0\r\na=sendonly\r\na=ssrc:1349455989 cname:0X2NGAsK9XcmnsuZ\r\na=ssrc:1349455989 msid:qUVEoh7TF9nLCrk4 qUVEoh7TF9nLCrk4-audio\r\na=msid:qUVEoh7TF9nLCrk4 qUVEoh7TF9nLCrk4-audio\r\na=rtcp-mux\r\na=rtpmap:111 opus/48000/2\r\na=fmtp:111 minptime=10;maxaveragebitrate=96000;stereo=1;sprop-stereo=1;useinbandfec=1\r\na=candidate:1 1 UDP 2015363327 192.168.0.198 4557 typ host\r\na=candidate:2 1 UDP 2015363583 fe80::6c3d:5b42:1532:2f9a 10007 typ host\r\na=end-of-candidates\r\nm=video 4557 UDP/TLS/RTP/SAVPF 96\r\nc=IN IP4 192.168.0.198\r\na=mid:1\r\na=sendonly\r\na=ssrc:1349455990 cname:0X2NGAsK9XcmnsuZ\r\na=ssrc:1349455990 msid:qUVEoh7TF9nLCrk4 qUVEoh7TF9nLCrk4-video\r\na=msid:qUVEoh7TF9nLCrk4 qUVEoh7TF9nLCrk4-video\r\na=rtcp-mux\r\na=rtpmap:96 H264/90000\r\na=rtcp-fb:96 nack\r\na=rtcp-fb:96 nack pli\r\na=rtcp-fb:96 goog-remb\r\na=fmtp:96 profile-level-id=42e01f;packetization-mode=1;level-asymmetry-allowed=1\r\n";
@@ -1686,7 +1718,10 @@ mod tests {
         mod get_streamer_video_session {
             use std::collections::HashSet;
 
-            use crate::line_parsers::{Attribute, Feedback, FeedbackType, FMTP, MediaCodec, MediaSSRC, RTPMap, SDPLine, Setup, SourceAttribute, VideoCodec};
+            use crate::line_parsers::{
+                Attribute, Feedback, FeedbackType, FMTP, MediaCodec, MediaSSRC, RTPMap, SDPLine,
+                Setup, SourceAttribute, VideoCodec,
+            };
             use crate::resolvers::{FeedbackSupport, HOST_CNAME, SDPResolver};
 
             #[test]
@@ -1713,8 +1748,7 @@ mod tests {
                     SDPLine::Attribute(Attribute::Feedback(Feedback {
                         payload_type: expected_payload_number,
                         feedback_type: FeedbackType::NACK,
-                    }))
-                    ,
+                    })),
                 ];
 
                 let video_session = SDPResolver::get_streamer_video_session(&video_media)
@@ -1724,10 +1758,13 @@ mod tests {
                 assert_eq!(video_session.payload_number, expected_payload_number);
                 assert_eq!(video_session.remote_ssrc, Some(expected_ssrc));
                 assert_eq!(video_session.capabilities, expected_capabilities);
-                assert_eq!(video_session.feedback_support, FeedbackSupport {
-                    supports_pli: false,
-                    supports_nack: true,
-                });
+                assert_eq!(
+                    video_session.feedback_support,
+                    FeedbackSupport {
+                        supports_pli: false,
+                        supports_nack: true,
+                    }
+                );
             }
 
             #[test]
@@ -2001,7 +2038,10 @@ mod tests {
         mod get_viewer_video_session {
             use std::collections::HashSet;
 
-            use crate::line_parsers::{Attribute, Feedback, FeedbackType, FMTP, MediaCodec, MediaSSRC, RTPMap, SDPLine, Setup, SourceAttribute, VideoCodec};
+            use crate::line_parsers::{
+                Attribute, Feedback, FeedbackType, FMTP, MediaCodec, MediaSSRC, RTPMap, SDPLine,
+                Setup, SourceAttribute, VideoCodec,
+            };
             use crate::resolvers::{FeedbackSupport, HOST_CNAME, SDPResolver, VideoSession};
 
             fn init_streamer_session() -> VideoSession {
@@ -2011,7 +2051,10 @@ mod tests {
                     remote_ssrc: Some(2),
                     host_ssrc: 1,
                     payload_number: 111,
-                    feedback_support: FeedbackSupport { supports_nack: true, supports_pli: false },
+                    feedback_support: FeedbackSupport {
+                        supports_nack: true,
+                        supports_pli: false,
+                    },
                 };
 
                 video_session
@@ -2054,7 +2097,10 @@ mod tests {
                 assert_eq!(video_session.payload_number, expected_payload_number);
                 assert_eq!(video_session.remote_ssrc, Some(expected_ssrc));
                 assert_eq!(video_session.capabilities, streamer_session.capabilities);
-                assert_eq!(video_session.feedback_support, streamer_session.feedback_support)
+                assert_eq!(
+                    video_session.feedback_support,
+                    streamer_session.feedback_support
+                )
             }
 
             #[test]

--- a/crates/sdp/tests/streamer_offer.rs
+++ b/crates/sdp/tests/streamer_offer.rs
@@ -469,4 +469,51 @@ mod streamer_offer {
             .accept_stream_offer(sdp_offer)
             .expect_err("Should reject SDP");
     }
+
+    #[test]
+    fn accepts_cc_offer() {
+        let sdp_offer = "v=0\r\n\
+        o=rtc 225794291 0 IN IP4 127.0.0.1\r\n\
+        s=-\r\n\
+        t=0 0\r\n\
+        a=group:BUNDLE 0 1\r\n\
+        a=group:LS 0 1\r\n\
+        a=msid-semantic:WMS *\r\n\
+        a=ice-options:ice2,trickle\r\n\
+        a=fingerprint:sha-256 C9:21:F3:0F:50:63:00:26:AD:E4:EE:5D:7A:98:CE:43:AF:3A:1B:6A:01:30:F1:26:D6:85:88:3B:03:64:43:5C\r\n\
+        m=audio 9 UDP/TLS/RTP/SAVPF 111\r\n\
+        c=IN IP4 0.0.0.0\r\n\
+        a=mid:0\r\n\
+        a=sendonly\r\n\
+        a=ssrc:2438577715 cname:nZyt7QWwcGJNsgO2\r\n\
+        a=ssrc:2438577715 msid:eaiGmkYyow7GTpQf eaiGmkYyow7GTpQf-audio\r\n\
+        a=msid:eaiGmkYyow7GTpQf eaiGmkYyow7GTpQf-audio\r\n\
+        a=rtcp-mux\r\n\
+        a=rtpmap:111 opus/48000/2\r\n\
+        a=fmtp:111 minptime=10;maxaveragebitrate=96000;stereo=1;sprop-stereo=1;useinbandfec=1\r\n\
+        a=setup:actpass\r\n\
+        a=ice-ufrag:VrFM\r\n\
+        a=ice-pwd:kzaq2oz4dMVSJbeJzzTNA8\r\n\
+        m=video 9 UDP/TLS/RTP/SAVPF 96\r\n\
+        c=IN IP4 0.0.0.0\r\n\
+        a=mid:1\r\n\
+        a=sendonly\r\n\
+        a=ssrc:2438577716 cname:nZyt7QWwcGJNsgO2\r\n\
+        a=ssrc:2438577716 msid:eaiGmkYyow7GTpQf eaiGmkYyow7GTpQf-video\r\n\
+        a=msid:eaiGmkYyow7GTpQf eaiGmkYyow7GTpQf-video\r\n\
+        a=rtcp-mux\r\n\
+        a=rtpmap:96 H264/90000\r\n\
+        a=rtcp-fb:96 nack\r\n\
+        a=rtcp-fb:96 nack pli\r\n\
+        a=rtcp-fb:96 goog-remb\r\n\
+        a=fmtp:96 profile-level-id=42e01f;packetization-mode=1;level-asymmetry-allowed=1\r\n\
+        a=setup:actpass\r\n\
+        a=ice-ufrag:VrFM\r\n\
+        a=ice-pwd:kzaq2oz4dMVSJbeJzzTNA8\r\n";
+
+        let sdp_resolver = init_sdp_resolver();
+        sdp_resolver
+            .accept_stream_offer(sdp_offer)
+            .expect("Should unwrap SDP");
+    }
 }


### PR DESCRIPTION
The `a=setup:` attribute may appear both in video and audio media sections. Search through entire SDP when checking for proper DTLS role